### PR TITLE
chg: dev: Check for capacitor.config.json on execution path

### DIFF
--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -1,9 +1,12 @@
 const path = require('path')
+const fs = require('fs-extra')
 
 module.exports = {
   getRootPath: () => {
+    console.log(`Root path: ${path.resolve()}`)
     const developmentRoot = path.resolve(__dirname, '../../')
-    const productionRoot = path.resolve(__dirname, '../../../../')
+    const productionRoot = fs.existsSync(path.resolve('capacitor.config.json')) ?
+      path.resolve() : path.resolve(__dirname, '../../../../')
     return process.env.CAPACITOR_RESOURCES_STAGE === 'development' ? developmentRoot : productionRoot
   }
 }


### PR DESCRIPTION
The path where the binary is executed is checked first for 
capacitor.config.json under production mode. In case the file exists, 
the working directory is set as the rootPath.

This patch fixes a not found rootPath issue when working with YARN.