### PR TITLE
Feature: use cover transformation for splash image

### DIFF
--- a/src/generate/index.js
+++ b/src/generate/index.js
@@ -199,6 +199,23 @@ function generateForConfig(imageObj, settings, config) {
   }
 
   const transformSplash = definition => {
+
+    const defer = Q.defer()
+    const image = imageObj.splash.clone()
+    
+    const width = definition.width
+    const height = definition.height
+
+    const outputFilePath = path.join(platformPath, definition.name)
+
+    image.cover(width, height).write(outputFilePath, err => {
+      if (err) defer.reject(err)
+      //display.info('Generated splash file for ' + outputFilePath);
+      defer.resolve()
+    })
+
+    return defer.promise
+/*
     const defer = Q.defer()
     const image = imageObj.splash.clone()
 
@@ -215,7 +232,7 @@ function generateForConfig(imageObj, settings, config) {
       defer.resolve()
     })
 
-    return defer.promise
+    return defer.promise */
   }
 
   return fs.ensureDir(platformPath).then(() => {

--- a/src/generate/index.js
+++ b/src/generate/index.js
@@ -198,43 +198,6 @@ function generateForConfig(imageObj, settings, config) {
     return defer.promise
   }
 
-  const transformSplash = definition => {
-
-    const defer = Q.defer()
-    const image = imageObj.splash.clone()
-    
-    const width = definition.width
-    const height = definition.height
-
-    const outputFilePath = path.join(platformPath, definition.name)
-
-    image.cover(width, height).write(outputFilePath, err => {
-      if (err) defer.reject(err)
-      //display.info('Generated splash file for ' + outputFilePath);
-      defer.resolve()
-    })
-
-    return defer.promise
-/*
-    const defer = Q.defer()
-    const image = imageObj.splash.clone()
-
-    const x = (image.bitmap.width - definition.width) / 2
-    const y = (image.bitmap.height - definition.height) / 2
-    const width = definition.width
-    const height = definition.height
-
-    const outputFilePath = path.join(platformPath, definition.name)
-
-    image.crop(x, y, width, height).write(outputFilePath, err => {
-      if (err) defer.reject(err)
-      //display.info('Generated splash file for ' + outputFilePath);
-      defer.resolve()
-    })
-
-    return defer.promise */
-  }
-
   return fs.ensureDir(platformPath).then(() => {
     const definitions = config.definitions
     const sectionName = 'Generating ' + config.type + ' files for ' + config.platform
@@ -257,7 +220,7 @@ function generateForConfig(imageObj, settings, config) {
           transformPromise = transformPromise.then(() => transformIcon(def))
           break
         case 'splash':
-          transformPromise = transformPromise.then(() => transformSplash(def))
+          transformPromise = transformPromise.then(() => transformSplash(def, imageObj, platformPath))
           break
       }
       return transformPromise
@@ -313,6 +276,7 @@ commander
   .description(pjson.description)
   .option('-i, --icon [optional]', 'optional icon file path (default: ./resources/icon.png)')
   .option('-s, --splash [optional]', 'optional splash file path (default: ./resources/splash.png)')
+  .option('-t, --transform-splash [crop|cover]', 'optional splash transformation', 'crop')
   .option(
     '-p, --platforms [optional]',
     'optional platform token comma separated list (default: all platforms processed)',
@@ -333,6 +297,19 @@ const settings = {
   makeicon: commander.makeicon || (!commander.makeicon && !commander.makesplash) ? true : false,
   makesplash: commander.makesplash || (!commander.makeicon && !commander.makesplash) ? true : false
 }
+
+
+// Dinamically set splash transformation function
+function setTransformationFunction(transformation){
+  switch (transformation){
+    case 'cover':
+      return require('./splash/cover.js');
+    default:
+      return require('./splash/crop.js');
+  }
+}
+const transformSplash = setTransformationFunction(commander.transformSplash)
+
 
 module.exports = () =>
   new Promise((resolve, reject) => {

--- a/src/generate/splash/cover.js
+++ b/src/generate/splash/cover.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+const Q = require('bluebird')
+const path = require('path')
+
+module.exports = (definition, imageObj, platformPath) => {
+  const defer = Q.defer()
+  const image = imageObj.splash.clone()
+
+  const width = definition.width
+  const height = definition.height
+
+  const outputFilePath = path.join(platformPath, definition.name)
+
+  image.cover(width, height).write(outputFilePath, err => {
+    if (err) defer.reject(err)
+    //display.info('Generated splash file for ' + outputFilePath);
+    defer.resolve()
+  })
+
+  return defer.promise
+}

--- a/src/generate/splash/crop.js
+++ b/src/generate/splash/crop.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+const Q = require('bluebird')
+const path = require('path')
+
+module.exports = (definition, imageObj, platformPath) => {
+  const defer = Q.defer()
+  const image = imageObj.splash.clone()
+
+  const x = (image.bitmap.width - definition.width) / 2
+  const y = (image.bitmap.height - definition.height) / 2
+  const width = definition.width
+  const height = definition.height
+
+  const outputFilePath = path.join(platformPath, definition.name)
+
+  image.crop(x, y, width, height).write(outputFilePath, err => {
+    if (err) defer.reject(err)
+    //display.info('Generated splash file for ' + outputFilePath);
+    defer.resolve()
+  })
+
+  return defer.promise
+}


### PR DESCRIPTION
Parametrizes "cover" usage and modularizes transformSplash function to allow dynamic import according to the desired transformation to apply. It uses "crop" by default and the user can choose among "cover" or "crop" using the -t or --transform-splash argument.

This PR includes the commits of PR #3 submitted by  @digaus and can by applied as substitution.