### PR TITLE
Bug Fix - Copy Android/iOS - Error: ENOENT: no such file or directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-resources",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Generates icon & splash screen for capacitor projects using javascript only.",
   "main": "index.js",
   "preferGlobal": true,

--- a/src/copy/index.js
+++ b/src/copy/index.js
@@ -37,9 +37,9 @@ module.exports = () => {
       const copyAndroid = path.join(__dirname, './platforms/android/index')
       const copyIOS = path.join(__dirname, './platforms/ios/index')
       // display.header('Copying resources to native projects...')
-      await exec(`npx cross-env CAPACITOR_PROJECT_ROOT=${paths.getRootPath()} node ${copyAndroid}`)
+      await exec(`npx cross-env CAPACITOR_PROJECT_ROOT="${paths.getRootPath()}" node "${copyAndroid}"`)
       // display.success('Copied android resources')
-      await exec(`npx cross-env CAPACITOR_PROJECT_ROOT=${paths.getRootPath()} node ${copyIOS}`)
+      await exec(`npx cross-env CAPACITOR_PROJECT_ROOT="${paths.getRootPath()}" node "${copyIOS}"`)
       // display.success('Copied iOS resources')
       resolve()
     } catch (e) {


### PR DESCRIPTION
## Description
This PR aims to fix the error referenced in https://github.com/leonardoquevedox/capacitor-resources/issues/7. This fixes the error by wrapping the paths in a string. This allows Node to parse the correct file path to the copy modules. Please reference this [Stack Overflow](https://stackoverflow.com/a/32262174) accepted answer as a form of proof.
Expected Impact

## Impact
This fix should have no impact on existing users and installations. This addresses how Node parsed the file path for an expected resource. This only affects the exec statements in src/copy/index.js by wrapping the file path inside of a string.
Tests

## Testing
This has been tested in a file path on windows c:\Users\first last\Projects\ionic-app and c:\Users\firstlast\Projects\ionic-app. This has also been tested with the same parameters on Mac OS Monterey with success.